### PR TITLE
Update README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ UNZIP = unzip -q -o
 VENDOR_SDK_ZIP = $(VENDOR_SDK_ZIP_$(VENDOR_SDK))
 VENDOR_SDK_DIR = $(VENDOR_SDK_DIR_$(VENDOR_SDK))
 
+VENDOR_SDK_ZIP_2.1.0 = ESP8266_NONOS_SDK-2.1.0.zip
+VENDOR_SDK_DIR_2.1.0 = ESP8266_NONOS_SDK-2.1.0
 VENDOR_SDK_ZIP_2.0.0 = ESP8266_NONOS_SDK_V2.0.0_16_08_10.zip
 VENDOR_SDK_DIR_2.0.0 = ESP8266_NONOS_SDK_V2.0.0_16_08_10
 VENDOR_SDK_ZIP_1.5.4 = ESP8266_NONOS_SDK_V1.5.4_16_05_20.zip
@@ -177,6 +179,10 @@ $(VENDOR_SDK_DIR)/.dir: $(VENDOR_SDK_ZIP)
 	-mv License $(VENDOR_SDK_DIR)
 	touch $@
 
+$(VENDOR_SDK_DIR_2.1.0)/.dir: $(VENDOR_SDK_ZIP_2.1.0)
+	$(UNZIP) $^
+	touch $@
+
 $(VENDOR_SDK_DIR_2.0.0)/.dir: $(VENDOR_SDK_ZIP_2.0.0)
 	$(UNZIP) $^
 	mv ESP8266_NONOS_SDK $(VENDOR_SDK_DIR_2.0.0)
@@ -190,6 +196,13 @@ $(VENDOR_SDK_DIR_1.5.4)/.dir: $(VENDOR_SDK_ZIP_1.5.4)
 	touch $@
 
 sdk_patch: $(VENDOR_SDK_DIR)/.dir .sdk_patch_$(VENDOR_SDK)
+
+.sdk_patch_2.1.0: user_rf_cal_sector_set.o
+	echo -e "#undef ESP_SDK_VERSION\n#define ESP_SDK_VERSION 020100" >>$(VENDOR_SDK_DIR)/include/esp_sdk_ver.h
+	$(PATCH) -d $(VENDOR_SDK_DIR) -p1 < c_types-c99_sdk_2.patch
+	cd $(VENDOR_SDK_DIR)/lib; mkdir -p tmp; cd tmp; $(TOOLCHAIN)/bin/xtensa-lx106-elf-ar x ../libcrypto.a; cd ..; $(TOOLCHAIN)/bin/xtensa-lx106-elf-ar rs libwpa.a tmp/*.o
+	$(TOOLCHAIN)/bin/xtensa-lx106-elf-ar r $(VENDOR_SDK_DIR)/lib/libmain.a user_rf_cal_sector_set.o
+	@touch $@
 
 .sdk_patch_2.0.0: ESP8266_NONOS_SDK_V2.0.0_patch_16_08_09.zip user_rf_cal_sector_set.o
 	echo -e "#undef ESP_SDK_VERSION\n#define ESP_SDK_VERSION 020000" >>$(VENDOR_SDK_DIR)/include/esp_sdk_ver.h
@@ -344,6 +357,9 @@ ifeq ($(STANDALONE),y)
 	    $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/include/
 endif
 
+
+ESP8266_NONOS_SDK-2.1.0.zip:
+	wget --content-disposition "https://github.com/espressif/ESP8266_NONOS_SDK/archive/v2.1.0.zip"
 # The only change wrt to ESP8266_NONOS_SDK_V2.0.0_16_07_19.zip is licensing blurb in source/
 # header files. Libs are the same (and patch is required just the same).
 ESP8266_NONOS_SDK_V2.0.0_16_08_10.zip:

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ ifeq ($(STANDALONE),y)
 endif
 
 clean: clean-sdk
-	make -C crosstool-NG clean MAKELEVEL=0
+	$(MAKE) -C crosstool-NG clean MAKELEVEL=0
 	-rm -rf crosstool-NG/.build/src
 	-rm -f crosstool-NG/local-patches/gcc/4.8.5/1000-*
 	-rm -rf $(TOOLCHAIN)
@@ -112,7 +112,7 @@ clean-sdk:
 	rm -f sdk
 	rm -f .sdk_patch_$(VENDOR_SDK)
 	rm -f user_rf_cal_sector_set.o empty_user_rf_pre_init.o
-	make -C esp-open-lwip -f Makefile.open clean
+	$(MAKE) -C esp-open-lwip -f Makefile.open clean
 
 clean-sysroot:
 	rm -rf $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/*
@@ -126,7 +126,7 @@ toolchain: $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
 
 $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc: crosstool-NG/ct-ng
 	cp -f 1000-mforce-l32.patch crosstool-NG/local-patches/gcc/4.8.5/
-	make -C crosstool-NG -f ../Makefile _toolchain
+	$(MAKE) -C crosstool-NG -f ../Makefile _toolchain
 
 _toolchain:
 	./ct-ng xtensa-lx106-elf
@@ -139,13 +139,13 @@ _toolchain:
 crosstool-NG: crosstool-NG/ct-ng
 
 crosstool-NG/ct-ng: crosstool-NG/bootstrap
-	make -C crosstool-NG -f ../Makefile _ct-ng
+	$(MAKE) -C crosstool-NG -f ../Makefile _ct-ng
 
 _ct-ng:
 	./bootstrap
 	./configure --prefix=`pwd`
-	make MAKELEVEL=0
-	make install MAKELEVEL=0
+	$(MAKE) MAKELEVEL=0
+	$(MAKE) install MAKELEVEL=0
 
 crosstool-NG/bootstrap:
 	@echo "You cloned without --recursive, fetching submodules for you."
@@ -161,13 +161,13 @@ $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/lib/libcirom.a: $(TOOLCHAIN)/xtensa-lx106-
 libhal: $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/libhal.a
 
 $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/libhal.a: $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
-	make -C lx106-hal -f ../Makefile _libhal
+	$(MAKE) -C lx106-hal -f ../Makefile _libhal
 
 _libhal:
 	autoreconf -i
 	PATH="$(TOOLCHAIN)/bin:$(PATH)" ./configure --host=xtensa-lx106-elf --prefix=$(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr
-	PATH="$(TOOLCHAIN)/bin:$(PATH)" make
-	PATH="$(TOOLCHAIN)/bin:$(PATH)" make install
+	PATH="$(TOOLCHAIN)/bin:$(PATH)" $(MAKE)
+	PATH="$(TOOLCHAIN)/bin:$(PATH)" $(MAKE) install
 
 
 
@@ -348,7 +348,7 @@ user_rf_cal_sector_set.o: user_rf_cal_sector_set.c $(TOOLCHAIN)/bin/xtensa-lx106
 
 lwip: toolchain sdk_patch
 ifeq ($(STANDALONE),y)
-	make -C esp-open-lwip -f Makefile.open install \
+	$(MAKE) -C esp-open-lwip -f Makefile.open install \
 	    CC=$(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc \
 	    AR=$(TOOLCHAIN)/bin/xtensa-lx106-elf-ar \
 	    PREFIX=$(TOOLCHAIN)

--- a/Makefile
+++ b/Makefile
@@ -165,9 +165,9 @@ $(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr/lib/libhal.a: $(TOOLCHAIN)/bin/xtensa-
 
 _libhal:
 	autoreconf -i
-	PATH=$(TOOLCHAIN)/bin:$(PATH) ./configure --host=xtensa-lx106-elf --prefix=$(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr
-	PATH=$(TOOLCHAIN)/bin:$(PATH) make
-	PATH=$(TOOLCHAIN)/bin:$(PATH) make install
+	PATH="$(TOOLCHAIN)/bin:$(PATH)" ./configure --host=xtensa-lx106-elf --prefix=$(TOOLCHAIN)/xtensa-lx106-elf/sysroot/usr
+	PATH="$(TOOLCHAIN)/bin:$(PATH)" make
+	PATH="$(TOOLCHAIN)/bin:$(PATH)" make install
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The complete SDK consists of:
 The source code above originates from work done directly by Tensilica Inc.,
 Cadence Design Systems, Inc, and/or their contractors.
 
-2. ESP8266 IoT SDK from Espressif Systems. This component is only
+2. ESP8266 NONOS SDK from Espressif Systems. This component is only
    partially open source, (some libraries are provided as binary blobs).
     * http://bbs.espressif.com/viewforum.php?f=46
 
@@ -81,22 +81,22 @@ $ git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
 
 The project can be built in two modes:
 
-1. Where the toolchain and tools are kept separate from the vendor IoT SDK
+1. Where the toolchain and tools are kept separate from the vendor NONOS SDK
    which contains binary blobs. This makes licensing more clear, and helps
    facilitate upgrades to vendor SDK releases.
 
 2. A completely standalone ESP8266 SDK with the vendor SDK files merged
    into the toolchain. This mode makes it easier to build software (no
    additinal `-I` and `-L` flags are needed), but redistributability of
-   this build is unclear and upgrades to newer vendor IoT SDK releases are
+   this build is unclear and upgrades to newer vendor NONOS SDK releases are
    complicated. This mode is default for local builds. Note that if you
    want to redistribute the binary toolchain built with this mode, you
    should:
 
     1. Make it clear to your users that the release is bound to a
-       particular vendor IoT SDK and provide instructions how to upgrade
-       to a newer vendor IoT SDK releases.
-    2. Abide by licensing terms of the vendor IoT SDK.
+       particular vendor NONOS SDK and provide instructions how to upgrade
+       to a newer vendor NONOS SDK releases.
+    2. Abide by licensing terms of the vendor NONOS SDK.
 
 To build the self-contained, standalone toolchain+SDK:
 

--- a/examples/blinky/Makefile
+++ b/examples/blinky/Makefile
@@ -11,7 +11,7 @@ blinky: blinky.o
 blinky.o: blinky.c
 
 flash: blinky-0x00000.bin
-	esptool.py write_flash 0 blinky-0x00000.bin 0x40000 blinky-0x40000.bin
+	esptool.py write_flash 0 blinky-0x00000.bin 0x10000 blinky-0x10000.bin
 
 clean:
-	rm -f blinky blinky.o blinky-0x00000.bin blinky-0x40000.bin
+	rm -f blinky blinky.o blinky-0x00000.bin blinky-0x10000.bin

--- a/examples/blinky/Makefile
+++ b/examples/blinky/Makefile
@@ -1,6 +1,6 @@
 CC = xtensa-lx106-elf-gcc
 CFLAGS = -I. -mlongcalls
-LDLIBS = -nostdlib -Wl,--start-group -lmain -lnet80211 -lwpa -llwip -lpp -lphy -Wl,--end-group -lgcc
+LDLIBS = -nostdlib -Wl,--start-group -lmain -lnet80211 -lwpa -llwip -lpp -lphy -lc -Wl,--end-group -lgcc
 LDFLAGS = -Teagle.app.v6.ld
 
 blinky-0x00000.bin: blinky

--- a/examples/blinky/blinky.c
+++ b/examples/blinky/blinky.c
@@ -23,7 +23,7 @@ void some_timerfunc(void *arg)
 
 void ICACHE_FLASH_ATTR user_init()
 {
-  // init gpio sussytem
+  // init gpio subsytem
   gpio_init();
 
   // configure UART TXD to be GPIO1, set as output

--- a/examples/blinky/blinky.c
+++ b/examples/blinky/blinky.c
@@ -3,7 +3,9 @@
 #include "gpio.h"
 #include "os_type.h"
 
-static const int pin = 1;
+// ESP-12 modules have LED on GPIO2. Change to another GPIO
+// for other boards.
+static const int pin = 2;
 static volatile os_timer_t some_timer;
 
 void some_timerfunc(void *arg)


### PR DESCRIPTION
change sdk name from IoT to NONOS
The NONOS SDK based on the IoT SDK has replaced the former SDK since 1.5.2 , to avoid confusion point to the correct SDK name in the readme